### PR TITLE
Fix menu rendering for Holy Paladin spec

### DIFF
--- a/classes/paladin/holy/logic/rotations/healing.lua
+++ b/classes/paladin/holy/logic/rotations/healing.lua
@@ -33,5 +33,11 @@ function FS.paladin_holy.logic.rotations.healing()
     if FS.paladin_holy.logic.spells.consecration() then
         return true
     end
+    if FS.paladin_holy.logic.spells.flash_of_light() then
+        return true
+    end
+    if FS.paladin_holy.logic.spells.holy_light() then
+        return true
+    end
     return false
 end

--- a/classes/paladin/holy/menu.lua
+++ b/classes/paladin/holy/menu.lua
@@ -70,6 +70,16 @@ FS.paladin_holy.menu = {
     awakening_header = FS.menu.header(),
     awakening_hp_threshold_slider = FS.menu.slider_int(1, 100, 80, tag .. "awakening_hp_threshold_slider"),
     awakening_min_targets_slider = FS.menu.slider_int(1, 10, 3, tag .. "awakening_min_targets_slider"),
+
+    -- Flash of Light settings
+    fol_header = FS.menu.header(),
+    fol_hp_threshold_slider = FS.menu.slider_int(1, 100, 85, tag .. "fol_hp_threshold_slider"),
+    fol_infusion_hp_threshold_slider = FS.menu.slider_int(1, 100, 90, tag .. "fol_infusion_hp_threshold_slider"),
+
+    -- Holy Light settings
+    hl_header = FS.menu.header(),
+    hl_hp_threshold_slider = FS.menu.slider_int(1, 100, 85, tag .. "hl_hp_threshold_slider"),
+    hl_infusion_hp_threshold_slider = FS.menu.slider_int(1, 100, 90, tag .. "hl_infusion_hp_threshold_slider"),
 }
 
 -- Helper function to render weight sliders
@@ -124,6 +134,18 @@ local function render_settings_window()
                         { slider = menu.awakening_min_targets_slider,  label = "Minimum Targets",  tooltip = "Minimum injured targets to optimize for procs" }
                     })
                 end
+
+                -- Flash of Light settings
+                FS.menu.render_settings_section(menu.settings_window, "Flash of Light", {
+                    { slider = menu.fol_hp_threshold_slider,             label = "Health Threshold",      tooltip = "Cast when target health falls below this percentage" },
+                    { slider = menu.fol_infusion_hp_threshold_slider,    label = "Infusion Threshold",    tooltip = "Cast when target health falls below this percentage with Infusion of Light" }
+                })
+
+                -- Holy Light settings
+                FS.menu.render_settings_section(menu.settings_window, "Holy Light", {
+                    { slider = menu.hl_hp_threshold_slider,             label = "Health Threshold",      tooltip = "Cast when target health falls below this percentage" },
+                    { slider = menu.hl_infusion_hp_threshold_slider,    label = "Infusion Threshold",    tooltip = "Cast when target health falls below this percentage with Infusion of Light" }
+                })
             end,
             -- Right Column
             function()

--- a/classes/paladin/holy/settings.lua
+++ b/classes/paladin/holy/settings.lua
@@ -64,5 +64,17 @@ FS.paladin_holy.settings = {
     ---@type fun(): number
     lod_hp_threshold = function() return FS.paladin_holy.menu.lod_hp_threshold_slider:get() / 100 end,
     ---@type fun(): number
-    lod_min_targets = function() return FS.paladin_holy.menu.lod_min_targets_slider:get() end
+    lod_min_targets = function() return FS.paladin_holy.menu.lod_min_targets_slider:get() end,
+
+    -- Flash of Light settings
+    ---@type fun(): number
+    fol_hp_threshold = function() return FS.paladin_holy.menu.fol_hp_threshold_slider:get() / 100 end,
+    ---@type fun(): number
+    fol_infusion_hp_threshold = function() return FS.paladin_holy.menu.fol_infusion_hp_threshold_slider:get() / 100 end,
+
+    -- Holy Light settings
+    ---@type fun(): number
+    hl_hp_threshold = function() return FS.paladin_holy.menu.hl_hp_threshold_slider:get() / 100 end,
+    ---@type fun(): number
+    hl_infusion_hp_threshold = function() return FS.paladin_holy.menu.hl_infusion_hp_threshold_slider:get() / 100 end
 }


### PR DESCRIPTION
Add missing spell logic calls and menu items for Paladin Holy spec.

* **Healing Rotation Logic**
  - Add missing spell logic calls for `flash_of_light` and `holy_light`.

* **Menu Items**
  - Add menu items for `flash_of_light` and `holy_light` settings.
  - Render new menu items for `flash_of_light` and `holy_light`.

* **Settings**
  - Add settings for `flash_of_light` and `holy_light`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NitashEU/fs_rotations/pull/8?shareId=b9522aa9-7d6b-4cae-8807-bcc274651344).